### PR TITLE
Add readarrv2 git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "readarr"]
 	path = readarr
 	url = https://github.com/Readarr/Readarr.git
+[submodule "readarrv2"]
+	path = readarrv2
+	url = https://github.com/Sonarr/Sonarr.git


### PR DESCRIPTION
Add a new `readarrv2` git submodule, mirroring the `sonarr` submodule's repository and commit hash.

---
<a href="https://cursor.com/background-agent?bcId=bc-f33945b5-434e-47d4-ae29-98e3bf7e59c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f33945b5-434e-47d4-ae29-98e3bf7e59c5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>